### PR TITLE
working cube

### DIFF
--- a/app/controllers/mdx_controller.rb
+++ b/app/controllers/mdx_controller.rb
@@ -2,7 +2,7 @@ class MdxController < ApplicationController
   def index
     @title = "Enter MDX query"
     if params[:q]
-      @result = Dwh.olap.execute(params[:q])
+      @result = Article.olap.execute(params[:q])
       format_result
     end
   end
@@ -10,7 +10,7 @@ class MdxController < ApplicationController
   def builder
     @title = "Enter query builder expression"
     if params[:q]
-      @query = Dwh.instance_eval(params[:q])
+      @query = Article.instance_eval(params[:q])
       @mdx = @query.to_mdx
       @result = @query.execute
       format_result

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,31 @@
+require 'mondrian-olap'
+require "vertica-jdbc-8.0.1-6.jar"
+
+class Article
+  def self.schema
+    @schema ||= Mondrian::OLAP::Schema.define do
+      cube 'Articles' do
+        table 'vt_fact_article_events'
+        cache false
+
+        dimension 'Device', foreign_key: 'device_id' do
+          hierarchy has_all: true, all_member_name: 'All Devices', primary_key: 'id' do
+            table 'vt_dim_devices'
+            level 'Device Type', column: 'device_type', unique_members: false
+          end
+        end
+
+        measure 'Views', column: 'views', aggregator: 'sum'
+      end
+    end
+  end
+
+  def self.olap
+    Mondrian::OLAP::Connection.create(
+      driver: 'jdbc',
+      jdbc_url: 'jdbc:vertica://52.44.235.220:5433/?user=ds_readonly&password=ds123_analytics',
+      jdbc_driver: 'com.vertica.jdbc.Driver',
+      schema: schema
+    )
+  end
+end

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -1,5 +1,5 @@
 # Set root logger level to DEBUG and its only appender to MONDRIAN.
-log4j.rootLogger=WARN, MONDRIAN
+log4j.rootLogger=DEBUG, MONDRIAN
 
 # MONDRIAN is set to be a ConsoleAppender.
 log4j.appender.MONDRIAN=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
I set it up so that you can send the app mdx queries to our Articles cube:

Goto `http://localhost:3000/mdx`

It all came down to using `primary_key` instead of `primary_id` in the cube schema.